### PR TITLE
Fix: Dispatching content to a specific editorFix: dispatch update for specific editor

### DIFF
--- a/resources/views/livewire/jodit-text-editor.blade.php
+++ b/resources/views/livewire/jodit-text-editor.blade.php
@@ -27,8 +27,8 @@
 
         window.addEventListener('update-jodit-content', (event) => {
             // Check if this is an array with [editorId, content]
-            if (Array.isArray(event.detail) && event.detail.length === 2) {
-                const [targetId, newContent] = event.detail;
+            if (Array.isArray(event.detail[0]) && event.detail[0].length === 2) {
+                const [targetId, newContent] = event.detail[0];
 
                 // Only update if the editor ID matches this instance
                 if (targetId === @js($identifier)) {


### PR DESCRIPTION
Problem:
Using `$this->dispatch('update-jodit-content', ['description-editor', 'hi']);`
did not update the editor and caused "Uncaught TypeError: value must be string".

Solution:
Check if event.detail[0] is an array of length 2 before updating the editor:

if (Array.isArray(event.detail[0]) && event.detail[0].length === 2) {
    const [targetId, newContent] = event.detail[0];
    const editor = Jodit.instances[targetId];
    if (editor) editor.value = newContent;
}

This allows dispatching content to a specific editor safely.
