### PR TITLE
Remove cached editors due to wire:ignore and wire:navigation

### DIFF
--- a/resources/views/livewire/jodit-text-editor.blade.php
+++ b/resources/views/livewire/jodit-text-editor.blade.php
@@ -4,6 +4,9 @@
 
 @script
     <script>
+        const textAreaElement = document.getElementById(@js($joditId));
+        textAreaElement.parentNode.querySelectorAll('.jodit').forEach(el => el.remove());
+
         const buttons = @json($buttons);
 
         const editor = Jodit.make('#' + @js($joditId), {
@@ -21,7 +24,7 @@
             "theme": "{{ $theme }}"
         });
 
-        document.getElementById(@js($joditId)).addEventListener('change', function() {
+        textAreaElement.addEventListener('change', function() {
             @this.set('value', this.value);
         });
 


### PR DESCRIPTION
Implementation for [Issue #12](https://github.com/Mantix/livewire-jodit-text-editor/issues/12)